### PR TITLE
YOR-27: Add CTA buttons to View block

### DIFF
--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -17,13 +17,18 @@
         class: bem(view__base_class, view__modifiers),
       } %}
   {% endif %}
-  
+
   <div {{ add_attributes(view__attibutes) }}>
     {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
       component_wrapper__width: component_wrapper__width|default('site'),
       component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
       {% block component_wrapper_inner %}
+        {% if content.field_heading_links %}
+          <div class="cta-group">
+            {{ content.field_heading_links|children }}
+          </div>
+        {% endif %}
         {% if content.field_view_params %}
           {{ content.field_view_params }}
         {% endif %}

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -24,7 +24,7 @@
       component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
       {% block component_wrapper_inner %}
-        {% if content.field_heading_links %}
+        {% if content.field_heading_links.0 %}
           <div class="cta-group">
             {{ content.field_heading_links|children }}
           </div>

--- a/templates/paragraphs/paragraph--cta-link.html.twig
+++ b/templates/paragraphs/paragraph--cta-link.html.twig
@@ -1,0 +1,4 @@
+{% include "@atoms/controls/text-link/yds-text-link.twig" with {
+  link__content: content.field_link.0['#title'],
+  link__url: content.field_link.0['#url_title'],
+} %}


### PR DESCRIPTION
## [YOR-27: Add CTA buttons to View block](https://ffwagency.atlassian.net/browse/YOR-27)

### Description of work
- Conditional rendering of the new 'field_heading_links' in the View block.

### Functional testing Steps
-  Click on 'Edit Layout And Content' on a Page CT.
-  Click on 'Add Block' in the Content Section.
-  Choose 'View' block
-  Complete needed fields. Add Heading Link(s)
- Verify that  Heading Link(s) are rendered above the block content