### PR TITLE
YOR-6: Add Content Type filter to Search Page

### DIFF
--- a/templates/node/node--search-result.html.twig
+++ b/templates/node/node--search-result.html.twig
@@ -4,5 +4,6 @@
   search_result__title: label,
   search_result__url: url,
   search_result__highlighted: content.search_api_excerpt,
-  search_result__teaser: content.field_teaser_text
+  search_result__teaser: content.field_teaser_text,
+  search_result__content_type: node.bundle|clean_class
 } %}


### PR DESCRIPTION
## [YOR-6: Add Content Type filter to Search Page](https://ffwagency.atlassian.net/browse/YOR-6)

### Description of work
- Render the content type label to the search result view mode node template.
